### PR TITLE
make TikaMW file access compatible with MediaWiki 1.21

### DIFF
--- a/TikaMW.php
+++ b/TikaMW.php
@@ -94,9 +94,10 @@ function efTikaSearchUpdate($id, $namespace, $title, &$text)
             $haclgEnableTitleCheck = false;
         }
         $file = wfFindFile($title);
-        if ($file && file_exists($file->getPath()))
+	
+        if ($file && $file->exists())
         {
-            $filetext = $cli->extractTextFromFile($file->getPath(), $file->getMimeType());
+            $filetext = $cli->extractTextFromFile($file->getLocalRefPath(), $file->getMimeType());
             if (defined('HACL_HALOACL_VERSION'))
             {
                 $haclgEnableTitleCheck = $etc;

--- a/TikaMW.php
+++ b/TikaMW.php
@@ -86,6 +86,24 @@ function efTikaSearchUpdate($id, $namespace, $title, &$text)
     if ($namespace == NS_FILE)
     {
         global $egTikaServer, $egTikaMimeTypes, $egTikaLogFile, $haclgEnableTitleCheck;
+        static $path_method = null;
+
+        // Starting with version 1.21, MediaWiki changed the API on the File 
+        // object wherein getPath() returned a mwstore URL rather than a path
+        // on the file system.  This logic resolves which API to call upon
+        // first invocation and caches the result in a static variable.
+        if (is_null($path_method)) 
+        {
+            if (method_exists('File', 'getLocalRefPath')) 
+            {
+                $path_method = 'getLocalRefPath';
+            }
+            else 
+            {
+                $path_method = 'getPath';
+            }
+        }
+        
         $cli = new TikaClient($egTikaServer, $egTikaMimeTypes, NULL, 'wfDebug', true);
         if (defined('HACL_HALOACL_VERSION'))
         {
@@ -93,11 +111,11 @@ function efTikaSearchUpdate($id, $namespace, $title, &$text)
             $etc = $haclgEnableTitleCheck;
             $haclgEnableTitleCheck = false;
         }
+
         $file = wfFindFile($title);
-	
-        if ($file && $file->exists())
+        if ($file && file_exists($file_path = $file->$path_method()))
         {
-            $filetext = $cli->extractTextFromFile($file->getLocalRefPath(), $file->getMimeType());
+            $filetext = $cli->extractTextFromFile($file_path, $file->getMimeType());
             if (defined('HACL_HALOACL_VERSION'))
             {
                 $haclgEnableTitleCheck = $etc;


### PR DESCRIPTION
MediaWiki changed their API for getting stored files.  As of
5275f9b097cdae5dbab0845e3ea127086e3a6570 on mediawiki/core,
File::getPath() no longer returns a path on the physical
file system.  Instead, it uses mwstore:// paths, which when
passed to PHP functions like file_exists() and file_get_contents(),
causes warnings.  The fix is to use File::exists() and 
File::getLocalRefPath() instead.  The rationale can be verified
by examining this diff:

https://git.wikimedia.org/commitdiff/mediawiki%2Fcore/5275f9b097cdae5dbab0845e3ea127086e3a6570

wherein one can see the old API calls getting replaced
with the new API.
